### PR TITLE
Enable optional aggregation

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
     <input type="text" id="start" value="2023-07-07T00:00:00Z">
     <label for="end">End:</label>
     <input type="text" id="end" value="2023-07-07T23:59:59Z">
+    <label for="shouldAggregate">Aggregate?</label>
+    <input type="checkbox" id="shouldAggregate">
+    <label for="aggregationSeparator">Separator:</label>
+    <input type="text" id="aggregationSeparator" value=":">
     <button id="generate">Generate</button>
     <h2>reST</h2>
     <pre><code id="rest">ReStructuredText will be rendered here...</code></pre>


### PR DESCRIPTION
For commits that have a consistent format (e.g. `category: commit message`), this allows you to aggregate commits by category.